### PR TITLE
Fix SDK constraint in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 homepage: https://github.com/matanlurey/kilobyte
 
 environment:
-  sdk: ">2.0.0 <=3.0.0"
+  sdk: ">=2.0.0 <=3.0.0"
 
 dependencies:
   meta: ^1.1.7


### PR DESCRIPTION
Pub marks this package as Dart 2 incompatible because the SDK constraint is `>2.0.0`. I changed it to `>=2.0.0`, which I assume will fix it.